### PR TITLE
Generic price data provider running. Looking to depeg next

### DIFF
--- a/src/v2/Controllers/ChainlinkPriceProvider.sol
+++ b/src/v2/Controllers/ChainlinkPriceProvider.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import "@chainlink/interfaces/AggregatorV3Interface.sol";
+import "@chainlink/interfaces/AggregatorV2V3Interface.sol";
+import {IVaultFactoryV2} from "../interfaces/IVaultFactoryV2.sol";
+import {IVaultV2} from "../interfaces/IVaultV2.sol";
+
+import "./IPriceProvider.sol";
+
+contract ChainlinkPriceProvider is IPriceProvider {
+    //AggregatorV3Interface internal priceFeed;
+    uint16 private constant GRACE_PERIOD_TIME = 3600;
+    
+    IVaultFactoryV2 public immutable vaultFactory;
+    AggregatorV2V3Interface internal sequencerUptimeFeed;
+
+    constructor(address _sequencer,address _factory) {
+        if (_factory == address(0)) revert ZeroAddress();
+        vaultFactory = IVaultFactoryV2(_factory);
+    
+        if (_sequencer == address(0)) revert ZeroAddress();
+        sequencerUptimeFeed = AggregatorV2V3Interface(_sequencer);
+        
+
+    }
+
+    /** @notice Lookup token price
+     * @param _token Target token address
+     * @return nowPrice Current token price
+     */
+    function getLatestPrice(address _token) public view returns (int256) {
+        (
+            ,
+            /*uint80 roundId*/
+            int256 answer,
+            uint256 startedAt, /*uint256 updatedAt*/ /*uint80 answeredInRound*/
+            ,
+
+        ) = sequencerUptimeFeed.latestRoundData();
+
+        // Answer == 0: Sequencer is up
+        // Answer == 1: Sequencer is down
+        bool isSequencerUp = answer == 0;
+        if (!isSequencerUp) {
+            revert SequencerDown();
+        }
+
+        // Make sure the grace period has passed after the sequencer is back up.
+        uint256 timeSinceUp = block.timestamp - startedAt;
+        if (timeSinceUp <= GRACE_PERIOD_TIME) {
+            revert GracePeriodNotOver();
+        }
+
+        AggregatorV3Interface priceFeed = AggregatorV3Interface(
+            vaultFactory.tokenToOracle(_token)
+        );
+        (uint80 roundID, int256 price, , , uint80 answeredInRound) = priceFeed
+            .latestRoundData();
+        uint256 decimals = priceFeed.decimals();
+
+        if (decimals < 18) {
+            decimals = 10**(18 - (decimals));
+            price = price * int256(decimals);
+        } else if (decimals == 18) {
+            price = price;
+        } else {
+            decimals = 10**((decimals - 18));
+            price = price / int256(decimals);
+        }
+
+        if (price <= 0) revert OraclePriceZero();
+
+        if (answeredInRound < roundID) revert RoundIDOutdated();
+
+        return price;
+    }
+    
+    
+    /*//////////////////////////////////////////////////////////////
+                                 ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    error MarketDoesNotExist(uint256 marketId);
+    error SequencerDown();
+    error GracePeriodNotOver();
+    error ZeroAddress();
+    error EpochFinishedAlready();
+    error PriceNotAtStrikePrice(int256 price);
+    error EpochNotStarted();
+    error EpochExpired();
+    error OraclePriceZero();
+    error RoundIDOutdated();
+    error EpochNotExist();
+    error EpochNotExpired();
+    error VaultNotZeroTVL();
+    error VaultZeroTVL();    
+}
+

--- a/src/v2/Controllers/ControllerGenericV2.sol
+++ b/src/v2/Controllers/ControllerGenericV2.sol
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {IVaultFactoryV2} from "../interfaces/IVaultFactoryV2.sol";
+import {IVaultV2} from "../interfaces/IVaultV2.sol";
+import "@chainlink/interfaces/AggregatorV3Interface.sol";
+import "@chainlink/interfaces/AggregatorV2V3Interface.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import "./IDepegCondition.sol";
+import "./IPriceProvider.sol";
+
+/// @author Y2K Finance Team
+
+contract ControllerGenericV2 {
+    using FixedPointMathLib for uint256;
+    IVaultFactoryV2 public immutable vaultFactory;
+    address public immutable treasury;
+
+
+    // Soon . . . IDepegCondition[] public depegConditions;
+    IPriceProvider public priceProvider;
+
+    constructor(
+        address _factory,
+        address _sequencer,
+        address _treasury,
+        address _priceProvider
+    ) {
+        if (_priceProvider == address(0)) revert ZeroAddress();
+        priceProvider = IPriceProvider(_priceProvider);
+        
+        if (_factory == address(0)) revert ZeroAddress();
+        vaultFactory = IVaultFactoryV2(_factory);
+        
+        treasury = _treasury;        
+    }
+    /*//////////////////////////////////////////////////////////////
+                                FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /** @notice Trigger depeg event
+     * @param _marketId Target market index
+     * @param _epochId End of epoch set for market
+     */
+    function triggerDepeg(uint256 _marketId, uint256 _epochId) public {
+        address[2] memory vaults = vaultFactory.getVaults(_marketId);
+
+        if (vaults[0] == address(0) || vaults[1] == address(0))
+            revert MarketDoesNotExist(_marketId);
+
+        IVaultV2 premiumVault = IVaultV2(vaults[0]);
+        IVaultV2 collateralVault = IVaultV2(vaults[1]);
+
+        if (premiumVault.epochExists(_epochId) == false) revert EpochNotExist();
+
+        int256 price = priceProvider.getLatestPrice(premiumVault.token());
+
+        if (int256(premiumVault.strike()) <= price)
+            revert PriceNotAtStrikePrice(price);
+
+        (uint40 epochStart, uint40 epochEnd, ) = premiumVault.getEpochConfig(
+            _epochId
+        );
+
+        if (uint256(epochStart) > block.timestamp) revert EpochNotStarted();
+
+        if (block.timestamp > uint256(epochEnd)) revert EpochExpired();
+
+        //require this function cannot be called twice in the same epoch for the same vault
+        if (premiumVault.epochResolved(_epochId)) revert EpochFinishedAlready();
+        if (collateralVault.epochResolved(_epochId))
+            revert EpochFinishedAlready();
+
+        // check if epoch qualifies for null epoch
+        if (
+            premiumVault.totalAssets(_epochId) == 0 ||
+            collateralVault.totalAssets(_epochId) == 0
+        ) {
+            revert VaultZeroTVL();
+        }
+
+        premiumVault.resolveEpoch(_epochId);
+        collateralVault.resolveEpoch(_epochId);
+
+        uint256 epochFee = vaultFactory.getEpochFee(_epochId);
+
+        uint256 premiumTVL = premiumVault.finalTVL(_epochId);
+        uint256 collateralTVL = collateralVault.finalTVL(_epochId);
+
+        uint256 premiumFee = calculateWithdrawalFeeValue(premiumTVL, epochFee);
+        uint256 collateralFee = calculateWithdrawalFeeValue(
+            collateralTVL,
+            epochFee
+        );
+
+        // avoid stack too deep error by avoiding local variables
+        // uint256 premiumTVLAfterFee = premiumTVL - premiumFee;
+        // uint256 collateralTVLAfterFee = collateralTVL - collateralFee;
+
+        premiumVault.setClaimTVL(_epochId, collateralTVL - collateralFee);
+        collateralVault.setClaimTVL(_epochId, premiumTVL - premiumFee);
+
+        // send fees to treasury and remaining TVL to respective counterparty vault
+        // strike price reached so premium is entitled to collateralTVL - collateralFee
+        premiumVault.sendTokens(_epochId, premiumFee, treasury);
+        premiumVault.sendTokens(
+            _epochId,
+            premiumTVL - premiumFee,
+            address(collateralVault)
+        );
+        // strike price is reached so collateral is still entitled to premiumTVL - premiumFee but looses collateralTVL
+        collateralVault.sendTokens(_epochId, collateralFee, treasury);
+        collateralVault.sendTokens(
+            _epochId,
+            collateralTVL - collateralFee,
+            address(premiumVault)
+        );
+
+        emit EpochResolved(
+            _epochId,
+            _marketId,
+            VaultTVL(
+                premiumTVL - premiumFee,
+                collateralTVL,
+                collateralTVL - collateralFee,
+                premiumTVL
+            ),
+            true,
+            block.timestamp,
+            price
+        );
+    }
+
+    /** @notice Trigger epoch end without depeg event
+     * @param _marketId Target market index
+     * @param _epochId End of epoch set for market
+     */
+    function triggerEndEpoch(uint256 _marketId, uint256 _epochId) public {
+        address[2] memory vaults = vaultFactory.getVaults(_marketId);
+
+        if (vaults[0] == address(0) || vaults[1] == address(0))
+            revert MarketDoesNotExist(_marketId);
+
+        IVaultV2 premiumVault = IVaultV2(vaults[0]);
+        IVaultV2 collateralVault = IVaultV2(vaults[1]);
+
+        if (
+            premiumVault.epochExists(_epochId) == false ||
+            collateralVault.epochExists(_epochId) == false
+        ) revert EpochNotExist();
+
+        (, uint40 epochEnd, ) = premiumVault.getEpochConfig(_epochId);
+
+        if (block.timestamp <= uint256(epochEnd)) revert EpochNotExpired();
+
+        //require this function cannot be called twice in the same epoch for the same vault
+        if (premiumVault.epochResolved(_epochId)) revert EpochFinishedAlready();
+        if (collateralVault.epochResolved(_epochId))
+            revert EpochFinishedAlready();
+
+        premiumVault.resolveEpoch(_epochId);
+        collateralVault.resolveEpoch(_epochId);
+
+        uint256 epochFee = vaultFactory.getEpochFee(_epochId);
+
+        uint256 premiumTVL = premiumVault.finalTVL(_epochId);
+        uint256 collateralTVL = collateralVault.finalTVL(_epochId);
+
+        uint256 premiumFee = calculateWithdrawalFeeValue(premiumTVL, epochFee);
+
+        uint256 premiumTVLAfterFee = premiumTVL - premiumFee;
+        uint256 collateralTVLAfterFee = collateralTVL + premiumTVLAfterFee;
+
+        // strike price is not reached so premium is entiled to 0
+        premiumVault.setClaimTVL(_epochId, 0);
+        // strike price is not reached so collateral is entitled to collateralTVL + premiumTVLAfterFee
+        collateralVault.setClaimTVL(_epochId, collateralTVLAfterFee);
+
+        // send premium fees to treasury and remaining TVL to collateral vault
+        premiumVault.sendTokens(_epochId, premiumFee, treasury);
+        // strike price reached so collateral is entitled to collateralTVLAfterFee
+        premiumVault.sendTokens(
+            _epochId,
+            premiumTVLAfterFee,
+            address(collateralVault)
+        );
+
+        emit EpochResolved(
+            _epochId,
+            _marketId,
+            VaultTVL(collateralTVLAfterFee, collateralTVL, 0, premiumTVL),
+            false,
+            block.timestamp,
+            0
+        );
+    }
+
+    /** @notice Trigger epoch invalid when one vault has 0 TVL
+     * @param _marketId Target market index
+     * @param _epochId End of epoch set for market
+     */
+    function triggerNullEpoch(uint256 _marketId, uint256 _epochId) public {
+        address[2] memory vaults = vaultFactory.getVaults(_marketId);
+
+        if (vaults[0] == address(0) || vaults[1] == address(0))
+            revert MarketDoesNotExist(_marketId);
+
+        IVaultV2 premiumVault = IVaultV2(vaults[0]);
+        IVaultV2 collateralVault = IVaultV2(vaults[1]);
+
+        if (
+            premiumVault.epochExists(_epochId) == false ||
+            collateralVault.epochExists(_epochId) == false
+        ) revert EpochNotExist();
+
+        (uint40 epochStart, , ) = premiumVault.getEpochConfig(_epochId);
+
+        if (block.timestamp < uint256(epochStart)) revert EpochNotStarted();
+
+        //require this function cannot be called twice in the same epoch for the same vault
+        if (premiumVault.epochResolved(_epochId)) revert EpochFinishedAlready();
+        if (collateralVault.epochResolved(_epochId))
+            revert EpochFinishedAlready();
+
+        //set claim TVL to final TVL if total assets are 0
+        if (premiumVault.totalAssets(_epochId) == 0) {
+            premiumVault.resolveEpoch(_epochId);
+            collateralVault.resolveEpoch(_epochId);
+
+            premiumVault.setClaimTVL(_epochId, 0);
+            collateralVault.setClaimTVL(
+                _epochId,
+                collateralVault.finalTVL(_epochId)
+            );
+
+            collateralVault.setEpochNull(_epochId);
+        } else if (collateralVault.totalAssets(_epochId) == 0) {
+            premiumVault.resolveEpoch(_epochId);
+            collateralVault.resolveEpoch(_epochId);
+
+            premiumVault.setClaimTVL(_epochId, premiumVault.finalTVL(_epochId));
+            collateralVault.setClaimTVL(_epochId, 0);
+
+            premiumVault.setEpochNull(_epochId);
+        } else revert VaultNotZeroTVL();
+
+        emit NullEpoch(
+            _epochId,
+            _marketId,
+            VaultTVL(
+                collateralVault.claimTVL(_epochId),
+                collateralVault.finalTVL(_epochId),
+                premiumVault.claimTVL(_epochId),
+                premiumVault.finalTVL(_epochId)
+            ),
+            block.timestamp
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                GETTERS
+    //////////////////////////////////////////////////////////////*/
+
+
+    /** @notice Lookup target VaultFactory address
+     * @dev need to find way to express typecasts in NatSpec
+     */
+    function getVaultFactory() external view returns (address) {
+        return address(vaultFactory);
+    }
+
+    /** @notice Calculate amount to withdraw after subtracting protocol fee
+     * @param amount Amount of tokens to withdraw
+     * @param fee Fee to be applied
+     */
+    function calculateWithdrawalFeeValue(uint256 amount, uint256 fee)
+        public
+        pure
+        returns (uint256 feeValue)
+    {
+        // 0.5% = multiply by 10000 then divide by 50
+        return amount.mulDivDown(fee, 10000);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                 ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    error MarketDoesNotExist(uint256 marketId);
+    error SequencerDown();
+    error GracePeriodNotOver();
+    error ZeroAddress();
+    error EpochFinishedAlready();
+    error PriceNotAtStrikePrice(int256 price);
+    error EpochNotStarted();
+    error EpochExpired();
+    error OraclePriceZero();
+    error RoundIDOutdated();
+    error EpochNotExist();
+    error EpochNotExpired();
+    error VaultNotZeroTVL();
+    error VaultZeroTVL();
+
+    /*//////////////////////////////////////////////////////////////
+                                 EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    /** @notice Resolves epoch when event is emitted
+     * @param epochId market epoch ID
+     * @param marketId market ID
+     * @param tvl TVL
+     * @param strikeMet Flag if event isDisaster
+     * @param time time
+     * @param depegPrice Price that triggered depeg
+     */
+    event EpochResolved(
+        uint256 indexed epochId,
+        uint256 indexed marketId,
+        VaultTVL tvl,
+        bool strikeMet,
+        uint256 time,
+        int256 depegPrice
+    );
+
+    /** @notice Sets epoch to null when event is emitted
+     * @param epochId market epoch ID
+     * @param marketId market ID
+     * @param tvl TVL
+     * @param time timestamp
+     */
+    event NullEpoch(
+        uint256 indexed epochId,
+        uint256 indexed marketId,
+        VaultTVL tvl,
+        uint256 time
+    );
+
+    struct VaultTVL {
+        uint256 COLLAT_claimTVL;
+        uint256 COLLAT_finalTVL;
+        uint256 PREM_claimTVL;
+        uint256 PREM_finalTVL;
+    }
+}

--- a/src/v2/Controllers/IDepegCondition.sol
+++ b/src/v2/Controllers/IDepegCondition.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.8.17;
+
+interface IDepegCondition {
+    function checkDepegCondition() external view returns (bool);
+}

--- a/src/v2/Controllers/IPriceProvider.sol
+++ b/src/v2/Controllers/IPriceProvider.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.8.17;
+
+interface IPriceProvider {
+    function getLatestPrice(address _token) external view returns (int256);
+}

--- a/src/v2/Controllers/PriceBasedDepegCondition.sol_inprogress
+++ b/src/v2/Controllers/PriceBasedDepegCondition.sol_inprogress
@@ -1,0 +1,19 @@
+pragma solidity 0.8.17;
+
+import "./IDepegCondition.sol";
+import "./IPriceProvider.sol";
+
+contract PriceBasedDepegCondition is IDepegCondition {
+    IPriceProvider public priceProvider;
+    uint256 public targetPrice;
+
+    constructor(IPriceProvider _priceProvider, uint256 _targetPrice) {
+        priceProvider = _priceProvider;
+        targetPrice = _targetPrice;
+    }
+
+    function checkDepegCondition() external view override returns (bool) {
+        uint256 currentPrice = priceProvider.getPrice();
+        return currentPrice <= targetPrice;
+    }
+}

--- a/test/V2/e2e/EndToEndV2GenericTest.t.sol
+++ b/test/V2/e2e/EndToEndV2GenericTest.t.sol
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import "../Helper.sol";
+import "../../../src/v2/VaultFactoryV2.sol";
+import "../../../src/v2/TimeLock.sol";
+import "../../../src/v2/VaultV2.sol";
+import "../../../src/v2/Controllers/ControllerGenericV2.sol";
+import "../../../src/v2/Controllers/ChainlinkPriceProvider.sol";
+import "../../../src/v2/Controllers/IPriceProvider.sol";
+
+
+
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+
+
+contract EndToEndV2Test is Helper {
+    using FixedPointMathLib for uint256;
+
+    VaultFactoryV2 public factory;
+    
+    IPriceProvider public priceProvider;
+    ControllerGenericV2 public controller;
+
+    address public premium;
+    address public collateral;
+    address public oracle;
+    address public depegPremium;
+    address public depegCollateral;
+
+    uint256 public marketId;
+    uint256 public strike;
+    uint256 public epochId;
+    uint256 public depegMarketId;
+    uint256 public depegStrike;
+    uint256 public depegEpochId;
+    uint256 public premiumShareValue;
+    uint256 public collateralShareValue;
+    uint256 public arbForkId;
+
+    uint256 public constant AMOUNT_AFTER_FEE = 19.95 ether;
+    uint256 public constant PREMIUM_DEPOSIT_AMOUNT = 2 ether;
+    uint256 public constant COLLAT_DEPOSIT_AMOUNT = 10 ether;
+    uint256 public constant DEPOSIT_AMOUNT = 10 ether;
+    uint256 public constant DEALT_AMOUNT = 20 ether;
+
+    uint40 public begin;
+    uint40 public end;
+
+    uint16 public fee;
+
+    string public ARBITRUM_RPC_URL = vm.envString("ARBITRUM_RPC_URL");
+
+    function setUp() public {
+        arbForkId = vm.createFork(ARBITRUM_RPC_URL);
+        vm.selectFork(arbForkId);
+        
+        UNDERLYING = address(new MintableToken("UnderLyingToken", "utkn"));
+
+        TimeLock timelock = new TimeLock(ADMIN);
+
+        factory = new VaultFactoryV2(
+                WETH,
+                TREASURY,
+                address(timelock)
+            );
+        
+        priceProvider = IPriceProvider(new ChainlinkPriceProvider(
+            ARBITRUM_SEQUENCER,
+            address(factory)
+            ));
+        controller = new ControllerGenericV2(
+                address(factory), 
+                ARBITRUM_SEQUENCER, 
+                TREASURY,
+                address(priceProvider));
+        factory.whitelistController(address(controller));
+        
+        //create end epoch market
+        oracle = address(0x3);
+        strike = uint256(0x2);
+        string memory name = string("USD Coin");
+        string memory symbol = string("USDC");
+
+        (
+            premium,
+            collateral,
+            marketId
+        ) = factory.createNewMarket(
+            VaultFactoryV2.MarketConfigurationCalldata(
+                TOKEN,
+                strike,
+                oracle,
+                UNDERLYING,
+                name,
+                symbol,
+                address(controller))
+        );
+        
+        //create depeg market
+        depegStrike = uint256(2 ether);
+        (
+            depegPremium,
+            depegCollateral,
+            depegMarketId
+        ) = factory.createNewMarket(
+           VaultFactoryV2.MarketConfigurationCalldata(
+                USDC_TOKEN,
+                depegStrike,
+                USDC_CHAINLINK,
+                UNDERLYING,
+                name,
+                symbol,
+                address(controller)
+            )
+        );
+
+        //create epoch for end epoch
+        begin = uint40(block.timestamp - 5 days);
+        end = uint40(block.timestamp - 3 days);
+        fee = 50; // 0.5%
+
+        (epochId, ) = factory.createEpoch(
+                marketId,
+                begin,
+                end,
+                fee
+       );
+
+       //create epoch for depeg
+        (depegEpochId, ) = factory.createEpoch(
+                depegMarketId,
+                begin,
+                end,
+                fee
+       );
+
+       MintableToken(UNDERLYING).mint(USER);
+    }
+
+    function testGenericEndToEndEndEpoch() public {
+        vm.startPrank(USER);
+
+        vm.warp(begin - 1 days);
+
+        //deal ether
+        vm.deal(USER, DEALT_AMOUNT);
+
+        //approve gov token
+        MintableToken(UNDERLYING).approve(premium, DEPOSIT_AMOUNT);
+        MintableToken(UNDERLYING).approve(collateral, DEPOSIT_AMOUNT);
+
+        //deposit in both vaults
+        VaultV2(premium).deposit(epochId, DEPOSIT_AMOUNT, USER);
+        VaultV2(collateral).deposit(epochId, DEPOSIT_AMOUNT, USER);
+
+        //check deposit balances
+        assertEq(VaultV2(premium).balanceOf(USER ,epochId), DEPOSIT_AMOUNT);
+        assertEq(VaultV2(collateral).balanceOf(USER ,epochId), DEPOSIT_AMOUNT);
+
+        //check user underlying balance
+        assertEq(USER.balance, DEALT_AMOUNT);
+
+        //warp to epoch end
+        vm.warp(end + 1 days);
+        
+        //trigger end of epoch
+        controller.triggerEndEpoch(marketId, epochId);
+
+        //check vault balances on withdraw
+        assertEq(VaultV2(premium).previewWithdraw(epochId, DEPOSIT_AMOUNT), 0);
+        assertEq(VaultV2(collateral).previewWithdraw(epochId, DEPOSIT_AMOUNT), AMOUNT_AFTER_FEE);
+
+        //withdraw from vaults
+        VaultV2(premium).withdraw(epochId, DEPOSIT_AMOUNT, USER, USER);
+        VaultV2(collateral).withdraw(epochId, DEPOSIT_AMOUNT, USER, USER);
+
+        //check vaults balance
+        assertEq(VaultV2(premium).balanceOf(USER ,epochId), 0);
+        assertEq(VaultV2(collateral).balanceOf(USER ,epochId), 0);
+
+        //check user ERC20 balance
+        assertEq(USER.balance, DEALT_AMOUNT);
+
+        vm.stopPrank();
+    }
+
+    function testEndToEndDepeg() public {
+        vm.startPrank(USER);
+
+        vm.warp(begin - 10 days);
+        //deal ether
+        vm.deal(USER, DEALT_AMOUNT);
+
+        //approve gov token
+        MintableToken(UNDERLYING).approve(depegPremium, PREMIUM_DEPOSIT_AMOUNT);
+        MintableToken(UNDERLYING).approve(depegCollateral, COLLAT_DEPOSIT_AMOUNT);
+
+        //deposit in both vaults
+        VaultV2(depegPremium).deposit(depegEpochId, PREMIUM_DEPOSIT_AMOUNT, USER);
+        VaultV2(depegCollateral).deposit(depegEpochId, COLLAT_DEPOSIT_AMOUNT, USER);
+
+        //check deposit balances
+        assertEq(VaultV2(depegPremium).balanceOf(USER ,depegEpochId), PREMIUM_DEPOSIT_AMOUNT);
+        assertEq(VaultV2(depegCollateral).balanceOf(USER ,depegEpochId), COLLAT_DEPOSIT_AMOUNT);
+
+        //check user underlying balance
+        assertEq(USER.balance, DEALT_AMOUNT);
+
+        //warp to epoch begin
+        vm.warp(begin + 1 hours);
+        
+        //trigger depeg
+        controller.triggerDepeg(depegMarketId, depegEpochId);
+
+        premiumShareValue = helperCalculateFeeAdjustedValue(VaultV2(depegCollateral).finalTVL(depegEpochId), fee);
+        collateralShareValue = helperCalculateFeeAdjustedValue(VaultV2(depegPremium).finalTVL(depegEpochId), fee);
+
+        //check vault balances on withdraw
+        assertEq(premiumShareValue, VaultV2(depegPremium).previewWithdraw(depegEpochId, PREMIUM_DEPOSIT_AMOUNT));
+        assertEq(collateralShareValue, VaultV2(depegCollateral).previewWithdraw(depegEpochId, COLLAT_DEPOSIT_AMOUNT));
+
+        //withdraw from vaults
+        VaultV2(depegPremium).withdraw(depegEpochId, PREMIUM_DEPOSIT_AMOUNT, USER, USER);
+        VaultV2(depegCollateral).withdraw(depegEpochId, COLLAT_DEPOSIT_AMOUNT, USER, USER);
+
+        //check vaults balance
+        assertEq(VaultV2(depegPremium).balanceOf(USER ,depegEpochId), 0);
+        assertEq(VaultV2(depegCollateral).balanceOf(USER ,depegEpochId), 0);
+
+        //check user ERC20 balance
+        assertEq(USER.balance, DEALT_AMOUNT);
+
+        vm.stopPrank();
+    }
+
+    function helperCalculateFeeAdjustedValue(uint256 amount, uint16 fee) internal pure returns (uint256) {
+        return amount - amount.mulDivUp(fee, 10000);
+    }
+}


### PR DESCRIPTION
-------------
DO NOT PULL (in progress)
-------------

This is a running version of a generic controller, meaning the stake price is generic. However, the dpeg event is still anchored to price data, and I am working on generalizing that with a generic condition interface. 

Interesting files: All in Controllers for now:
[Controllers ](https://github.com/Y2K-Finance/Earthquake/tree/earthquake-v2-controller-data/src/v2/Controllers)
---------
- ControllerGenericV2.sol - A controller with some work in progress around moving price out
- ChainlinkPriceProvider.sol & IPriceProvider.sol - A first pass at a provider which provides on demand price data when requested 
- PriceBasedDepegCondition.sol_inprogress & IDepegCondition.sol - (in progress) a Generic Depeg condition trigger, that rests on top of any IPriceProvider.
- EndToEndV2GenericTest.t.sol - Test case, which sets up the ControllerGenericV2 and tests it.
-----

As I am still onboarding, I chose to create a new controller and independent EndToEndV2GenericTest, as to not disrupt any other class.
