### PR TITLE
Strike Condition contained in _strike price

### DIFF
--- a/script/v2/V2DeployConfig.s.sol
+++ b/script/v2/V2DeployConfig.s.sol
@@ -74,12 +74,6 @@ contract V2DeployConfig is HelperV2 {
             address depositAsset = getDepositAsset(market.depositAsset);
             uint256 strikePrice = stringToUint(market.strikePrice);
             CarouselFactory localFactory = factory;
-            if (market.isGenericController) {
-                if (market.isDepeg && strikePrice % 2 ** 1 != 0)
-                    strikePrice += 1;
-                else if (!market.isDepeg && strikePrice % 2 ** 1 != 1)
-                    strikePrice += 1;
-            }
             (address prem, address collat, uint256 marketId) = localFactory
                 .createNewCarouselMarket(
                     CarouselFactory.CarouselMarketConfigurationCalldata(
@@ -145,6 +139,13 @@ contract V2DeployConfig is HelperV2 {
                     depositAsset
                 );
                 revert("Market already deployed");
+            }
+
+            if (market.isGenericController) {
+                if (market.isDepeg && strikePrice % 2 ** 1 != 0)
+                    revert("Strike price must be even");
+                else if (!market.isDepeg && strikePrice % 2 ** 1 != 1)
+                    revert("Strike price must be odd");
             }
         }
     }

--- a/src/v2/interfaces/IConditionProvider.sol
+++ b/src/v2/interfaces/IConditionProvider.sol
@@ -13,11 +13,4 @@ interface IConditionProvider {
         external
         view
         returns (uint80, int256, uint256, uint256, uint80);
-
-    function marketIdToConditionType(uint256 _marketId)
-        external
-        view
-        returns (uint256);
-    
-    function setConditionType(uint256 _marketId, uint256 _condition) external;
 }

--- a/src/v2/oracles/individual/CVIPriceProvider.sol
+++ b/src/v2/oracles/individual/CVIPriceProvider.sol
@@ -79,16 +79,7 @@ contract CVIPriceProvider is Ownable, IConditionProvider {
         uint256 /* _marketId */
     ) public view virtual returns (bool, int256 price) {
         uint256 conditionType = _strike % 2 ** 1;
-        assembly {
-            // conditionType := and(
-            //     0x000000000000000000000000000000000000000000000000000000000000000f,
-            //     _strike
-            // )
-            _strike := and(
-                0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0,
-                _strike
-            )
-        }
+        if (conditionType == 1) _strike -= 1;
 
         price = getLatestPrice();
         if (conditionType == 1) return (int256(_strike) < price, price);

--- a/src/v2/oracles/individual/CVIPriceProvider.sol
+++ b/src/v2/oracles/individual/CVIPriceProvider.sol
@@ -79,7 +79,6 @@ contract CVIPriceProvider is Ownable, IConditionProvider {
         uint256 /* _marketId */
     ) public view virtual returns (bool, int256 price) {
         uint256 conditionType = _strike % 2 ** 1;
-        if (conditionType == 1) _strike -= 1;
 
         price = getLatestPrice();
         if (conditionType == 1) return (int256(_strike) < price, price);

--- a/src/v2/oracles/individual/ChainlinkPriceProvider.sol
+++ b/src/v2/oracles/individual/ChainlinkPriceProvider.sol
@@ -11,8 +11,6 @@ import {IVaultFactoryV2} from "../../interfaces/IVaultFactoryV2.sol";
 import {IConditionProvider} from "../../interfaces/IConditionProvider.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
-import "forge-std/console.sol";
-
 contract ChainlinkPriceProvider is Ownable, IConditionProvider {
     uint16 private constant _GRACE_PERIOD_TIME = 3600;
     uint256 public immutable timeOut;
@@ -101,25 +99,15 @@ contract ChainlinkPriceProvider is Ownable, IConditionProvider {
 
     /** @notice Fetch price and return condition
      * @param _strike Strike price
-     * @param _marketId Market id
      * @return boolean If condition is met i.e. strike > price
      * @return price Current price for token
      */
     function conditionMet(
         uint256 _strike,
-        uint256 _marketId
+        uint256 /* _marketId */
     ) public view virtual returns (bool, int256 price) {
         uint256 conditionType = _strike % 2 ** 1;
-        assembly {
-            // conditionType := and(
-            //     0x000000000000000000000000000000000000000000000000000000000000000f,
-            //     _strike
-            // )
-            _strike := and(
-                0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0,
-                _strike
-            )
-        }
+        if (conditionType == 1) _strike -= 1;
 
         price = getLatestPrice();
         if (conditionType == 1) return (int256(_strike) < price, price);

--- a/src/v2/oracles/individual/ChainlinkPriceProvider.sol
+++ b/src/v2/oracles/individual/ChainlinkPriceProvider.sol
@@ -107,7 +107,6 @@ contract ChainlinkPriceProvider is Ownable, IConditionProvider {
         uint256 /* _marketId */
     ) public view virtual returns (bool, int256 price) {
         uint256 conditionType = _strike % 2 ** 1;
-        if (conditionType == 1) _strike -= 1;
 
         price = getLatestPrice();
         if (conditionType == 1) return (int256(_strike) < price, price);

--- a/src/v2/oracles/individual/DIAPriceProvider.sol
+++ b/src/v2/oracles/individual/DIAPriceProvider.sol
@@ -60,7 +60,6 @@ contract DIAPriceProvider is Ownable, IConditionProvider {
         uint256 /* _marketId */
     ) public view virtual returns (bool condition, int256 price) {
         uint256 conditionType = _strike % 2 ** 1;
-        if (conditionType == 1) _strike -= 1;
 
         (price, ) = _getLatestPrice();
         if (conditionType == 1) return (int256(_strike) < price, price);

--- a/src/v2/oracles/individual/DIAPriceProvider.sol
+++ b/src/v2/oracles/individual/DIAPriceProvider.sol
@@ -60,17 +60,7 @@ contract DIAPriceProvider is Ownable, IConditionProvider {
         uint256 /* _marketId */
     ) public view virtual returns (bool condition, int256 price) {
         uint256 conditionType = _strike % 2 ** 1;
-
-        assembly {
-            // conditionType := and(
-            //     0x00000000000000000000000000000000000000000000000000000000000000f,
-            //     _strike
-            // )
-            _strike := and(
-                0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0,
-                _strike
-            )
-        }
+        if (conditionType == 1) _strike -= 1;
 
         (price, ) = _getLatestPrice();
         if (conditionType == 1) return (int256(_strike) < price, price);

--- a/src/v2/oracles/individual/DIAPriceProvider.sol
+++ b/src/v2/oracles/individual/DIAPriceProvider.sol
@@ -13,27 +13,12 @@ contract DIAPriceProvider is Ownable, IConditionProvider {
     uint256 public immutable decimals;
     string public constant description = "BTC/USD";
 
-    mapping(uint256 => uint256) public marketIdToConditionType;
-
     event MarketConditionSet(uint256 indexed marketId, uint256 conditionType);
 
     constructor(address _priceFeed, uint256 _decimals) {
         if (_priceFeed == address(0)) revert ZeroAddress();
         diaPriceFeed = IDIAPriceFeed(_priceFeed);
         decimals = _decimals;
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                                 ADMIN
-    //////////////////////////////////////////////////////////////*/
-    function setConditionType(
-        uint256 _marketId,
-        uint256 _condition
-    ) external onlyOwner {
-        if (marketIdToConditionType[_marketId] != 0) revert ConditionTypeSet();
-        if (_condition != 1 && _condition != 2) revert InvalidInput();
-        marketIdToConditionType[_marketId] = _condition;
-        emit MarketConditionSet(_marketId, _condition);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -67,19 +52,29 @@ contract DIAPriceProvider is Ownable, IConditionProvider {
      * @dev The strike is hashed as an int256 to enable comparison vs. price for earthquake
         and conditional check vs. strike to ensure vaidity
      * @param _strike Strike price
-     * @param _marketId Market ID
      * @return condition boolean If condition is met i.e. strike > price
      * @return price current price for token
      */
     function conditionMet(
         uint256 _strike,
-        uint256 _marketId
+        uint256 /* _marketId */
     ) public view virtual returns (bool condition, int256 price) {
-        uint256 conditionType = marketIdToConditionType[_marketId];
-        (price, ) = _getLatestPrice();
+        uint256 conditionType = _strike % 2 ** 1;
 
+        assembly {
+            // conditionType := and(
+            //     0x00000000000000000000000000000000000000000000000000000000000000f,
+            //     _strike
+            // )
+            _strike := and(
+                0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0,
+                _strike
+            )
+        }
+
+        (price, ) = _getLatestPrice();
         if (conditionType == 1) return (int256(_strike) < price, price);
-        else if (conditionType == 2) return (int256(_strike) > price, price);
+        else if (conditionType == 0) return (int256(_strike) > price, price);
         else revert ConditionTypeNotSet();
     }
 

--- a/src/v2/oracles/individual/GdaiPriceProvider.sol
+++ b/src/v2/oracles/individual/GdaiPriceProvider.sol
@@ -5,12 +5,12 @@ import {IConditionProvider} from "../../interfaces/IConditionProvider.sol";
 import {IGdaiPriceFeed} from "../../interfaces/IGdaiPriceFeed.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
+import "forge-std/console.sol";
+
 contract GdaiPriceProvider is IConditionProvider, Ownable {
     IGdaiPriceFeed public immutable gdaiPriceFeed;
     uint256 public immutable decimals;
     string public description;
-
-    mapping(uint256 => uint256) public marketIdToConditionType;
 
     event MarketConditionSet(uint256 indexed marketId, uint256 conditionType);
 
@@ -19,19 +19,6 @@ contract GdaiPriceProvider is IConditionProvider, Ownable {
         gdaiPriceFeed = IGdaiPriceFeed(_priceFeed);
         decimals = gdaiPriceFeed.decimals();
         description = "gTrade pnl";
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                                 ADMIN
-    //////////////////////////////////////////////////////////////*/
-    function setConditionType(
-        uint256 _marketId,
-        uint256 _condition
-    ) external onlyOwner {
-        if (marketIdToConditionType[_marketId] != 0) revert ConditionTypeSet();
-        if (_condition != 1 && _condition != 2) revert InvalidInput();
-        marketIdToConditionType[_marketId] = _condition;
-        emit MarketConditionSet(_marketId, _condition);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -79,14 +66,24 @@ contract GdaiPriceProvider is IConditionProvider, Ownable {
      */
     function conditionMet(
         uint256 _strike,
-        uint256 _marketId
+        uint256 /* _marketId */
     ) public view virtual returns (bool condition, int256 price) {
         int256 strikeInt = int256(_strike);
-        uint256 conditionType = marketIdToConditionType[_marketId];
-        price = getLatestPrice();
+        console.log("Strike", _strike);
+        uint256 conditionType = _strike % 2 ** 1;
 
+        assembly {
+            strikeInt := and(
+                0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0,
+                strikeInt
+            )
+        }
+        console.logInt(strikeInt);
+        console.log("conditionType", conditionType);
+
+        price = getLatestPrice();
         if (conditionType == 1) return (strikeInt < price, price);
-        else if (conditionType == 2) return (strikeInt > price, price);
+        else if (conditionType == 0) return (strikeInt > price, price);
         else revert ConditionTypeNotSet();
     }
 

--- a/src/v2/oracles/individual/GdaiPriceProvider.sol
+++ b/src/v2/oracles/individual/GdaiPriceProvider.sol
@@ -5,8 +5,6 @@ import {IConditionProvider} from "../../interfaces/IConditionProvider.sol";
 import {IGdaiPriceFeed} from "../../interfaces/IGdaiPriceFeed.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
-import "forge-std/console.sol";
-
 contract GdaiPriceProvider is IConditionProvider, Ownable {
     IGdaiPriceFeed public immutable gdaiPriceFeed;
     uint256 public immutable decimals;
@@ -69,17 +67,7 @@ contract GdaiPriceProvider is IConditionProvider, Ownable {
         uint256 /* _marketId */
     ) public view virtual returns (bool condition, int256 price) {
         int256 strikeInt = int256(_strike);
-        console.log("Strike", _strike);
         uint256 conditionType = _strike % 2 ** 1;
-
-        assembly {
-            strikeInt := and(
-                0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0,
-                strikeInt
-            )
-        }
-        console.logInt(strikeInt);
-        console.log("conditionType", conditionType);
 
         price = getLatestPrice();
         if (conditionType == 1) return (strikeInt < price, price);

--- a/src/v2/oracles/individual/GdaiPriceProvider.sol
+++ b/src/v2/oracles/individual/GdaiPriceProvider.sol
@@ -67,7 +67,7 @@ contract GdaiPriceProvider is IConditionProvider, Ownable {
         uint256 /* _marketId */
     ) public view virtual returns (bool condition, int256 price) {
         int256 strikeInt = int256(_strike);
-        uint256 conditionType = strikeInt % 2 ** 1;
+        uint256 conditionType = _strike % 2 ** 1;
 
         price = getLatestPrice();
         if (conditionType == 1) return (strikeInt < price, price);

--- a/src/v2/oracles/individual/GdaiPriceProvider.sol
+++ b/src/v2/oracles/individual/GdaiPriceProvider.sol
@@ -67,7 +67,7 @@ contract GdaiPriceProvider is IConditionProvider, Ownable {
         uint256 /* _marketId */
     ) public view virtual returns (bool condition, int256 price) {
         int256 strikeInt = int256(_strike);
-        uint256 conditionType = _strike % 2 ** 1;
+        uint256 conditionType = strikeInt % 2 ** 1;
 
         price = getLatestPrice();
         if (conditionType == 1) return (strikeInt < price, price);

--- a/src/v2/oracles/individual/PythPriceProvider.sol
+++ b/src/v2/oracles/individual/PythPriceProvider.sol
@@ -79,7 +79,6 @@ contract PythPriceProvider is Ownable, IConditionProvider {
         uint256 /* _marketId */
     ) public view virtual returns (bool, int256 price) {
         uint256 conditionType = _strike % 2 ** 1;
-        if (conditionType == 1) _strike -= 1;
 
         price = getLatestPrice();
         if (conditionType == 1) return (int256(_strike) < price, price);

--- a/src/v2/oracles/individual/PythPriceProvider.sol
+++ b/src/v2/oracles/individual/PythPriceProvider.sol
@@ -68,7 +68,10 @@ contract PythPriceProvider is Ownable, IConditionProvider {
      * @return int256 Current token price
      */
     function getLatestPrice() public view virtual returns (int256) {
-        PythStructs.Price memory answer = pyth.getPriceNoOlderThan(priceFeedId, timeOut);
+        PythStructs.Price memory answer = pyth.getPriceNoOlderThan(
+            priceFeedId,
+            timeOut
+        );
         if (answer.price <= 0) revert OraclePriceNegative();
 
         int256 price = answer.price;

--- a/src/v2/oracles/individual/PythPriceProvider.sol
+++ b/src/v2/oracles/individual/PythPriceProvider.sol
@@ -15,8 +15,6 @@ contract PythPriceProvider is Ownable, IConditionProvider {
     uint256 public immutable timeOut;
     bytes32 public immutable priceFeedId;
 
-    mapping(uint256 => uint256) public marketIdToConditionType;
-
     event MarketConditionSet(uint256 indexed marketId, uint256 conditionType);
 
     error ExponentTooSmall(int256 expo);
@@ -30,19 +28,6 @@ contract PythPriceProvider is Ownable, IConditionProvider {
         timeOut = _timeOut;
         PythStructs.Price memory answer = pyth.getPriceUnsafe(priceFeedId);
         decimals = (int256(-answer.expo)).toUint256();
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                                 ADMIN
-    //////////////////////////////////////////////////////////////*/
-    function setConditionType(
-        uint256 _marketId,
-        uint256 _condition
-    ) external onlyOwner {
-        if (marketIdToConditionType[_marketId] != 0) revert ConditionTypeSet();
-        if (_condition != 1 && _condition != 2) revert InvalidInput();
-        marketIdToConditionType[_marketId] = _condition;
-        emit MarketConditionSet(_marketId, _condition);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -91,13 +76,14 @@ contract PythPriceProvider is Ownable, IConditionProvider {
      */
     function conditionMet(
         uint256 _strike,
-        uint256 _marketId
+        uint256 /* _marketId */
     ) public view virtual returns (bool, int256 price) {
-        uint256 conditionType = marketIdToConditionType[_marketId];
-        price = getLatestPrice();
+        uint256 conditionType = _strike % 2 ** 1;
+        if (conditionType == 1) _strike -= 1;
 
+        price = getLatestPrice();
         if (conditionType == 1) return (int256(_strike) < price, price);
-        else if (conditionType == 2) return (int256(_strike) > price, price);
+        else if (conditionType == 0) return (int256(_strike) > price, price);
         else revert ConditionTypeNotSet();
     }
 

--- a/src/v2/oracles/individual/RedstonePriceProvider.sol
+++ b/src/v2/oracles/individual/RedstonePriceProvider.sol
@@ -96,7 +96,6 @@ contract RedstonePriceProvider is Ownable, IConditionProvider {
         uint256 /* _marketId */
     ) public view virtual returns (bool, int256 price) {
         uint256 conditionType = _strike % 2 ** 1;
-        if (conditionType == 1) _strike -= 1;
 
         price = getLatestPrice();
         if (conditionType == 1) return (int256(_strike) < price, price);

--- a/src/v2/oracles/individual/RedstonePriceProvider.sol
+++ b/src/v2/oracles/individual/RedstonePriceProvider.sol
@@ -14,8 +14,6 @@ contract RedstonePriceProvider is Ownable, IConditionProvider {
     uint256 public immutable decimals;
     string public description;
 
-    mapping(uint256 => uint256) public marketIdToConditionType;
-
     event MarketConditionSet(uint256 indexed marketId, uint256 conditionType);
 
     constructor(
@@ -35,19 +33,6 @@ contract RedstonePriceProvider is Ownable, IConditionProvider {
         dataFeedId = stringToBytes32(_dataFeedSymbol);
         timeOut = _timeOut;
         decimals = priceFeedAdapter.decimals();
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                                 ADMIN
-    //////////////////////////////////////////////////////////////*/
-    function setConditionType(
-        uint256 _marketId,
-        uint256 _condition
-    ) external onlyOwner {
-        if (marketIdToConditionType[_marketId] != 0) revert ConditionTypeSet();
-        if (_condition != 1 && _condition != 2) revert InvalidInput();
-        marketIdToConditionType[_marketId] = _condition;
-        emit MarketConditionSet(_marketId, _condition);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -108,13 +93,24 @@ contract RedstonePriceProvider is Ownable, IConditionProvider {
      */
     function conditionMet(
         uint256 _strike,
-        uint256 _marketId
+        uint256 /* _marketId */
     ) public view virtual returns (bool, int256 price) {
-        uint256 conditionType = marketIdToConditionType[_marketId];
-        price = getLatestPrice();
+        uint256 conditionType = _strike % 2 ** 1;
 
+        assembly {
+            // conditionType := and(
+            //     0x00000000000000000000000000000000000000000000000000000000000000f,
+            //     _strike
+            // )
+            _strike := and(
+                0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0,
+                _strike
+            )
+        }
+
+        price = getLatestPrice();
         if (conditionType == 1) return (int256(_strike) < price, price);
-        else if (conditionType == 2) return (int256(_strike) > price, price);
+        else if (conditionType == 0) return (int256(_strike) > price, price);
         else revert ConditionTypeNotSet();
     }
 

--- a/src/v2/oracles/individual/RedstonePriceProvider.sol
+++ b/src/v2/oracles/individual/RedstonePriceProvider.sol
@@ -96,17 +96,7 @@ contract RedstonePriceProvider is Ownable, IConditionProvider {
         uint256 /* _marketId */
     ) public view virtual returns (bool, int256 price) {
         uint256 conditionType = _strike % 2 ** 1;
-
-        assembly {
-            // conditionType := and(
-            //     0x00000000000000000000000000000000000000000000000000000000000000f,
-            //     _strike
-            // )
-            _strike := and(
-                0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0,
-                _strike
-            )
-        }
+        if (conditionType == 1) _strike -= 1;
 
         price = getLatestPrice();
         if (conditionType == 1) return (int256(_strike) < price, price);

--- a/src/v2/oracles/universal/RedstoneCoreUniversalProvider.sol
+++ b/src/v2/oracles/universal/RedstoneCoreUniversalProvider.sol
@@ -5,7 +5,11 @@ import {IUniversalProvider} from "../../interfaces/IUniversalProvider.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import "@redstone-finance/evm-connector/contracts/data-services/PrimaryProdDataServiceConsumerBase.sol";
 
-contract RedstoneCoreUniversalProvider is Ownable, PrimaryProdDataServiceConsumerBase, IUniversalProvider {
+contract RedstoneCoreUniversalProvider is
+    Ownable,
+    PrimaryProdDataServiceConsumerBase,
+    IUniversalProvider
+{
     uint256 public immutable timeOut;
 
     mapping(uint256 => uint256) public marketIdToConditionType;
@@ -18,7 +22,11 @@ contract RedstoneCoreUniversalProvider is Ownable, PrimaryProdDataServiceConsume
         uint256 indexed marketId,
         uint256 indexed conditionType
     );
-    event DataFeedSet(uint256 indexed marketId, bytes32 priceFeed, uint256 decimals);
+    event DataFeedSet(
+        uint256 indexed marketId,
+        bytes32 priceFeed,
+        uint256 decimals
+    );
 
     constructor(uint256 _timeOut) {
         if (_timeOut == 0) revert InvalidInput();
@@ -41,12 +49,12 @@ contract RedstoneCoreUniversalProvider is Ownable, PrimaryProdDataServiceConsume
     function setPriceFeed(
         uint256 _marketId,
         bytes32 dataFeed,
-        uint256 decimals
+        uint256 _decimals
     ) external onlyOwner {
         if (dataFeed == bytes32(0)) revert InvalidInput();
         marketIdToDataFeed[_marketId] = dataFeed;
-        marketIdToDecimals[_marketId] = decimals;
-        emit DataFeedSet(_marketId, dataFeed, decimals);
+        marketIdToDecimals[_marketId] = _decimals;
+        emit DataFeedSet(_marketId, dataFeed, _decimals);
     }
 
     function updatePrices(uint256[] memory _marketIds) external {
@@ -54,26 +62,34 @@ contract RedstoneCoreUniversalProvider is Ownable, PrimaryProdDataServiceConsume
         uint256 length = _marketIds.length;
         for (uint256 i = 0; i < length; i += 1) {
             marketIdToPrice[_marketIds[i]] = prices[i];
-            marketIdToUpdatedAt[_marketIds[i]] = extractTimestampsAndAssertAllAreEqual() / 1000;
+            marketIdToUpdatedAt[_marketIds[i]] =
+                extractTimestampsAndAssertAllAreEqual() /
+                1000;
         }
     }
+
     /*//////////////////////////////////////////////////////////////
                                  PUBLIC
     //////////////////////////////////////////////////////////////*/
-    function decimals(uint256 marketId) public view returns (uint256 decimals) {
-        decimals = marketIdToDecimals[marketId];
+    function decimals(
+        uint256 marketId
+    ) public view returns (uint256 _decimals) {
+        _decimals = marketIdToDecimals[marketId];
     }
 
     function description(
         uint256 _marketId
     ) public view returns (string memory) {
-        return
-            string(
-                abi.encodePacked(marketIdToDataFeed[_marketId])
-            );
+        return string(abi.encodePacked(marketIdToDataFeed[_marketId]));
     }
- 
-    function getCurrentPrices(uint256[] memory _marketIds) public view returns (uint256[] memory prices, uint256[] memory updatedAt) {
+
+    function getCurrentPrices(
+        uint256[] memory _marketIds
+    )
+        public
+        view
+        returns (uint256[] memory prices, uint256[] memory updatedAt)
+    {
         uint256 length = _marketIds.length;
         prices = new uint256[](length);
         updatedAt = new uint256[](length);
@@ -83,15 +99,19 @@ contract RedstoneCoreUniversalProvider is Ownable, PrimaryProdDataServiceConsume
         }
     }
 
-    function getDataFeeds(uint256[] memory _marketIds) public view returns (bytes32[] memory dataFeeds) {
+    function getDataFeeds(
+        uint256[] memory _marketIds
+    ) public view returns (bytes32[] memory dataFeeds) {
         uint256 length = _marketIds.length;
         dataFeeds = new bytes32[](length);
         for (uint256 i = 0; i < length; i += 1) {
             dataFeeds[i] = marketIdToDataFeed[_marketIds[i]];
-        }        
+        }
     }
 
-    function extractPrice(uint256[] memory _marketIds) public view returns (uint256[] memory price) {
+    function extractPrice(
+        uint256[] memory _marketIds
+    ) public view returns (uint256[] memory price) {
         bytes32[] memory dataFeeds = getDataFeeds(_marketIds);
         return getOracleNumericValuesFromTxMsg(dataFeeds);
     }
@@ -119,12 +139,7 @@ contract RedstoneCoreUniversalProvider is Ownable, PrimaryProdDataServiceConsume
     function getLatestPrice(
         uint256 _marketId
     ) public view virtual returns (int256) {
-        (
-            ,
-            int256 price,
-            ,
-            uint256 updatedAt,
-        ) = latestRoundData(_marketId);
+        (, int256 price, , uint256 updatedAt, ) = latestRoundData(_marketId);
         if (price <= 0) revert OraclePriceZero();
         if ((block.timestamp - updatedAt) > timeOut) revert PriceTimedOut();
 
@@ -157,6 +172,7 @@ contract RedstoneCoreUniversalProvider is Ownable, PrimaryProdDataServiceConsume
         else if (conditionType == 2) return (int256(_strike) > price, price);
         else revert ConditionTypeNotSet();
     }
+
     /*//////////////////////////////////////////////////////////////
                                  ERRORS
     //////////////////////////////////////////////////////////////*/

--- a/test/V2/Controllers/ControllerGenericTest.t.sol
+++ b/test/V2/Controllers/ControllerGenericTest.t.sol
@@ -86,8 +86,6 @@ contract ControllerGenericTest is Helper {
                 address(controller)
             )
         );
-        uint256 condition = 2;
-        redstoneProvider.setConditionType(marketId, condition);
 
         begin = uint40(block.timestamp - 5 days);
         end = uint40(block.timestamp - 3 days);

--- a/test/V2/Helper.sol
+++ b/test/V2/Helper.sol
@@ -55,9 +55,11 @@ contract Helper is Test {
     uint256 public constant DIA_DECIMALS = 18;
     address public constant CVI_ORACLE =
         0x649813B6dc6111D67484BaDeDd377D32e4505F85;
-    uint256 public constant CVI_DECIMALS = 18;
-    address public constant PYTH_CONTRACT = 0xff1a0f4744e8582DF1aE09D5611b887B6a12925C;
-    bytes32 public constant PYTH_FDUSD_FEED_ID = 0xccdc1a08923e2e4f4b1e6ea89de6acbc5fe1948e9706f5604b8cb50bc1ed3979;
+    uint256 public constant CVI_DECIMALS = 0;
+    address public constant PYTH_CONTRACT =
+        0xff1a0f4744e8582DF1aE09D5611b887B6a12925C;
+    bytes32 public constant PYTH_FDUSD_FEED_ID =
+        0xccdc1a08923e2e4f4b1e6ea89de6acbc5fe1948e9706f5604b8cb50bc1ed3979;
     address public constant RELAYER = address(0x55);
     address public UNDERLYING = address(0x123);
     address public TOKEN = address(new MintableToken("Token", "tkn"));

--- a/test/V2/e2e/EndToEndGenericTest.t.sol
+++ b/test/V2/e2e/EndToEndGenericTest.t.sol
@@ -98,8 +98,6 @@ contract EndToEndV2GenericTest is Helper {
                 address(controller)
             )
         );
-        uint256 condition = 2;
-        redstoneProvider.setConditionType(marketId, condition);
 
         depegStrike = 0.1 ether * 10 ** 18;
         (depegPremium, depegCollateral, depegMarketId) = factory
@@ -114,7 +112,6 @@ contract EndToEndV2GenericTest is Helper {
                     address(controller)
                 )
             );
-        redstoneProvider.setConditionType(depegMarketId, condition);
 
         begin = uint40(block.timestamp);
         end = uint40(block.timestamp + 3 days);
@@ -161,8 +158,6 @@ contract EndToEndV2GenericTest is Helper {
                     address(controller)
                 )
             );
-        uint256 condition = 2;
-        chainlinkProvider.setConditionType(depegMarketId, condition);
 
         (depegEpochId, ) = factory.createEpoch(depegMarketId, begin, end, fee);
         MintableToken(UNDERLYING).mint(USER);
@@ -204,8 +199,6 @@ contract EndToEndV2GenericTest is Helper {
                     address(controller)
                 )
             );
-        uint256 condition = 1;
-        chainlinkProvider.setConditionType(depegMarketId, condition);
 
         (depegEpochId, ) = factory.createEpoch(depegMarketId, begin, end, fee);
         MintableToken(UNDERLYING).mint(USER);
@@ -221,6 +214,7 @@ contract EndToEndV2GenericTest is Helper {
 
         gdaiPriceProvider = new GdaiPriceProvider(GDAI_VAULT);
         int256 strikePrice = (gdaiPriceProvider.getLatestPrice() + 1);
+        if (strikePrice % 2 ** 1 != 0) strikePrice += 1;
         depegStrike = uint256(-strikePrice);
 
         string memory name = string("Gains Network DAI");
@@ -237,8 +231,6 @@ contract EndToEndV2GenericTest is Helper {
                     address(controller)
                 )
             );
-        uint256 condition = 2;
-        gdaiPriceProvider.setConditionType(depegMarketId, condition);
 
         (depegEpochId, ) = factory.createEpoch(depegMarketId, begin, end, fee);
         MintableToken(UNDERLYING).mint(USER);
@@ -270,8 +262,6 @@ contract EndToEndV2GenericTest is Helper {
                     address(controller)
                 )
             );
-        uint256 condition = 2;
-        diaPriceProvider.setConditionType(depegMarketId, condition);
 
         (depegEpochId, ) = factory.createEpoch(depegMarketId, begin, end, fee);
         MintableToken(UNDERLYING).mint(USER);
@@ -307,8 +297,6 @@ contract EndToEndV2GenericTest is Helper {
                     address(controller)
                 )
             );
-        uint256 condition = 1;
-        cviPriceProvider.setConditionType(depegMarketId, condition);
 
         (depegEpochId, ) = factory.createEpoch(depegMarketId, begin, end, fee);
         MintableToken(UNDERLYING).mint(USER);

--- a/test/V2/oracles/individual/CVIPriceProvider.t.sol
+++ b/test/V2/oracles/individual/CVIPriceProvider.t.sol
@@ -33,9 +33,6 @@ contract CVIPriceProviderTest is Helper {
             TIME_OUT,
             CVI_DECIMALS
         );
-
-        uint256 condition = 1;
-        cviPriceProvider.setConditionType(marketId, condition);
     }
 
     ////////////////////////////////////////////////
@@ -72,8 +69,9 @@ contract CVIPriceProviderTest is Helper {
     }
 
     function testConditionOneMetCVI() public {
+        uint256 strikePrice = 101; // 1100101
         (bool condition, int256 price) = cviPriceProvider.conditionMet(
-            100,
+            strikePrice,
             marketId
         );
         assertTrue(price != 0);
@@ -81,11 +79,11 @@ contract CVIPriceProviderTest is Helper {
     }
 
     function testConditionTwoMetCVI() public {
-        uint256 conditionType = 2;
         uint256 marketIdTwo = 2;
-        cviPriceProvider.setConditionType(marketIdTwo, conditionType);
+        uint256 strikePrice = 0.1 ether;
+
         (bool condition, int256 price) = cviPriceProvider.conditionMet(
-            0.1 ether,
+            strikePrice,
             marketIdTwo
         );
         assertTrue(price != 0);
@@ -101,19 +99,6 @@ contract CVIPriceProviderTest is Helper {
 
         vm.expectRevert(CVIPriceProvider.InvalidInput.selector);
         new CVIPriceProvider(CVI_ORACLE, 0, CVI_DECIMALS);
-    }
-
-    function testRevertConditionTypeSetCVI() public {
-        vm.expectRevert(CVIPriceProvider.ConditionTypeSet.selector);
-        cviPriceProvider.setConditionType(1, 0);
-    }
-
-    function testRevertInvalidInputConditionCVI() public {
-        vm.expectRevert(CVIPriceProvider.InvalidInput.selector);
-        cviPriceProvider.setConditionType(0, 0);
-
-        vm.expectRevert(CVIPriceProvider.InvalidInput.selector);
-        cviPriceProvider.setConditionType(0, 3);
     }
 
     function testRevertOraclePriceZeroCVI() public {

--- a/test/V2/oracles/individual/CVIPriceProvider.t.sol
+++ b/test/V2/oracles/individual/CVIPriceProvider.t.sol
@@ -80,7 +80,7 @@ contract CVIPriceProviderTest is Helper {
 
     function testConditionTwoMetCVI() public {
         uint256 marketIdTwo = 2;
-        uint256 strikePrice = 0.1 ether;
+        uint256 strikePrice = 0.1 ether * 10 ** 18;
 
         (bool condition, int256 price) = cviPriceProvider.conditionMet(
             strikePrice,
@@ -88,6 +88,66 @@ contract CVIPriceProviderTest is Helper {
         );
         assertTrue(price != 0);
         assertEq(condition, true);
+    }
+
+    function testConditionModuloCVI() public {
+        uint256 marketIdOne = 1;
+
+        uint256 newStrike = 32222872726273485958746564738398; // Last bit is a 0
+        (bool condition, int256 price) = cviPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 8889999573829384654738291019874637282864372; // Last bit is a 0
+        (condition, price) = cviPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 335162336; // Last bit is a 0
+        (condition, price) = cviPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+
+        newStrike = 574832910; // Last bit is a 0
+        (condition, price) = cviPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+
+        newStrike = 778872637281; // Last bit is a 1
+        (condition, price) = cviPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 2271718293; // Last bit is a 1
+        (condition, price) = cviPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 9900000000049475684939287919117; // Last bit is a 1
+        (condition, price) = cviPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+
+        newStrike = 11901981727465654748499383745647383899283; // Last bit is a 1
+        (condition, price) = cviPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
     }
 
     ////////////////////////////////////////////////

--- a/test/V2/oracles/individual/ChainlinkPriceProvider.t.sol
+++ b/test/V2/oracles/individual/ChainlinkPriceProvider.t.sol
@@ -148,6 +148,66 @@ contract ChainlinkPriceProviderTest is Helper {
         assertEq(condition, true);
     }
 
+    function testConditionModuloChainlink() public {
+        uint256 marketIdOne = 1;
+
+        uint256 newStrike = 213455566777700000002; // Last bit is a 0
+        (bool condition, int256 price) = chainlinkPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 102223334448556960000002226; // Last bit is a 0
+        (condition, price) = chainlinkPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 2134438; // Last bit is a 0
+        (condition, price) = chainlinkPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+
+        newStrike = 601882234; // Last bit is a 0
+        (condition, price) = chainlinkPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+
+        newStrike = 376599999919; // Last bit is a 1
+        (condition, price) = chainlinkPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 788561; // Last bit is a 1
+        (condition, price) = chainlinkPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 7888885647778390201112345655; // Last bit is a 1
+        (condition, price) = chainlinkPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+
+        newStrike = 8889949596059547392010293; // Last bit is a 1
+        (condition, price) = chainlinkPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+    }
+
     ////////////////////////////////////////////////
     //              REVERT CASES                  //
     ////////////////////////////////////////////////

--- a/test/V2/oracles/individual/ChainlinkPriceProvider.t.sol
+++ b/test/V2/oracles/individual/ChainlinkPriceProvider.t.sol
@@ -40,8 +40,6 @@ contract ChainlinkPriceProviderTest is Helper {
             USDC_CHAINLINK,
             TIME_OUT
         );
-        uint256 condition = 2;
-        chainlinkPriceProvider.setConditionType(marketId, condition);
 
         // NOTE: Keeping the vol tests in for now
         vm.selectFork(arbGoerliForkId);
@@ -51,9 +49,6 @@ contract ChainlinkPriceProviderTest is Helper {
             ETH_VOL_CHAINLINK,
             TIME_OUT
         );
-        condition = 1;
-        uint256 marketIdOne = 1;
-        chainlinkPriceProviderV2.setConditionType(marketIdOne, condition);
 
         vm.selectFork(arbForkId);
     }
@@ -132,11 +127,11 @@ contract ChainlinkPriceProviderTest is Helper {
     }
 
     function testConditionOneMetChainlink() public {
-        uint256 conditionType = 1;
         uint256 marketIdOne = 1;
-        chainlinkPriceProvider.setConditionType(marketIdOne, conditionType);
+        uint256 strikePrice = 1000000000000001;
+
         (bool condition, int256 price) = chainlinkPriceProvider.conditionMet(
-            0.001 ether,
+            strikePrice,
             marketIdOne
         );
         assertTrue(price != 0);
@@ -144,8 +139,9 @@ contract ChainlinkPriceProviderTest is Helper {
     }
 
     function testConditionTwoMetChainlink() public {
+        uint256 strikePrice = 2 ether;
         (bool condition, int256 price) = chainlinkPriceProvider.conditionMet(
-            2 ether,
+            strikePrice,
             marketId
         );
         assertTrue(price != 0);
@@ -187,16 +183,6 @@ contract ChainlinkPriceProviderTest is Helper {
             USDC_CHAINLINK,
             0
         );
-    }
-
-    function testRevertConditionTypeSetChainlink() public {
-        vm.expectRevert(ChainlinkPriceProvider.ConditionTypeSet.selector);
-        chainlinkPriceProvider.setConditionType(2, 0);
-    }
-
-    function testRevertInvalidInputConditionChainlink() public {
-        vm.expectRevert(ChainlinkPriceProvider.InvalidInput.selector);
-        chainlinkPriceProvider.setConditionType(0, 0);
     }
 
     function testRevertSequencerDownChainlink() public {

--- a/test/V2/oracles/individual/DIAPriceProvider.t.sol
+++ b/test/V2/oracles/individual/DIAPriceProvider.t.sol
@@ -29,7 +29,6 @@ contract DIAPriceProviderTest is Helper {
         vm.selectFork(arbForkId);
 
         diaPriceProvider = new DIAPriceProvider(DIA_ORACLE_V2, DIA_DECIMALS);
-        uint256 condition = 2;
     }
 
     ////////////////////////////////////////////////
@@ -87,6 +86,67 @@ contract DIAPriceProviderTest is Helper {
         );
         assertTrue(price != 0);
         assertEq(condition, true);
+    }
+
+    function testConditionModuloDIA() public {
+        uint256 marketIdOne = 1;
+
+        uint256 newStrike = 84847783399292726464738939392022; // Last bit is a 0
+        (bool condition, int256 price) = diaPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertTrue(price != 0);
+        assertEq(condition, true);
+
+        newStrike = 112384757584930384785590; // Last bit is a 0
+        (condition, price) = diaPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 90002873714; // Last bit is a 0
+        (condition, price) = diaPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+
+        newStrike = 4235662; // Last bit is a 0
+        (condition, price) = diaPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+
+        newStrike = 3248901; // Last bit is a 1
+        (condition, price) = diaPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 7668937287; // Last bit is a 1
+        (condition, price) = diaPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 9983736474893928272637484839393938477463737221; // Last bit is a 1
+        (condition, price) = diaPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+
+        newStrike = 765435346282947654937364747858498282761689; // Last bit is a 1
+        (condition, price) = diaPriceProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
     }
 
     ////////////////////////////////////////////////

--- a/test/V2/oracles/individual/DIAPriceProvider.t.sol
+++ b/test/V2/oracles/individual/DIAPriceProvider.t.sol
@@ -19,7 +19,6 @@ contract DIAPriceProviderTest is Helper {
     DIAPriceProvider public diaPriceProvider;
     uint256 public arbForkId;
     string public pairName = "BTC/USD";
-    uint256 public strikePrice = 50_000e8;
     uint256 public marketId = 2;
 
     ////////////////////////////////////////////////
@@ -31,7 +30,6 @@ contract DIAPriceProviderTest is Helper {
 
         diaPriceProvider = new DIAPriceProvider(DIA_ORACLE_V2, DIA_DECIMALS);
         uint256 condition = 2;
-        diaPriceProvider.setConditionType(marketId, condition);
     }
 
     ////////////////////////////////////////////////
@@ -70,11 +68,11 @@ contract DIAPriceProviderTest is Helper {
     }
 
     function testConditionOneMetDIA() public {
-        uint256 conditionType = 1;
         uint256 marketIdOne = 1;
-        diaPriceProvider.setConditionType(marketIdOne, conditionType);
+        uint256 strike = 10_000_000_0001; // 10e8 with extra byte as 1
+
         (bool condition, int256 price) = diaPriceProvider.conditionMet(
-            10e6,
+            strike,
             marketIdOne
         );
         assertTrue(price != 0);
@@ -82,6 +80,7 @@ contract DIAPriceProviderTest is Helper {
     }
 
     function testConditionTwoMetDIA() public {
+        uint256 strikePrice = 50_000e8; // 50k with extra byte as 1
         (bool condition, int256 price) = diaPriceProvider.conditionMet(
             strikePrice,
             marketId
@@ -96,18 +95,5 @@ contract DIAPriceProviderTest is Helper {
     function testRevertConstructorInputs() public {
         vm.expectRevert(DIAPriceProvider.ZeroAddress.selector);
         new DIAPriceProvider(address(0), DIA_DECIMALS);
-    }
-
-    function testRevertConditionTypeSetDIA() public {
-        vm.expectRevert(DIAPriceProvider.ConditionTypeSet.selector);
-        diaPriceProvider.setConditionType(2, 0);
-    }
-
-    function testRevertInvalidInputConditionDIA() public {
-        vm.expectRevert(DIAPriceProvider.InvalidInput.selector);
-        diaPriceProvider.setConditionType(0, 0);
-
-        vm.expectRevert(DIAPriceProvider.InvalidInput.selector);
-        diaPriceProvider.setConditionType(0, 3);
     }
 }

--- a/test/V2/oracles/individual/GdaiPriceProvider.t.sol
+++ b/test/V2/oracles/individual/GdaiPriceProvider.t.sol
@@ -72,7 +72,7 @@ contract GdaiPriceProviderTest is Helper {
         assertTrue(price != 0);
     }
 
-    function testConditionGdaiMasking() public {
+    function testConditionModuloGdai() public {
         uint256 marketIdOne = 1;
 
         int256 newStrike = -10000000000000000053; // Last bit is a 1
@@ -88,7 +88,6 @@ contract GdaiPriceProviderTest is Helper {
             uint256(newStrike),
             marketIdOne
         );
-        assertTrue(price != 0);
         assertEq(condition, true);
 
         newStrike = -10000000000000000012; // Last bit is a 0

--- a/test/V2/oracles/individual/PythPriceProvider.t.sol
+++ b/test/V2/oracles/individual/PythPriceProvider.t.sol
@@ -32,9 +32,6 @@ contract PythPriceProviderTest is Helper {
             PYTH_FDUSD_FEED_ID,
             TIME_OUT
         );
-
-        uint256 condition = 2;
-        pythProvider.setConditionType(marketId, condition);
     }
 
     ////////////////////////////////////////////////
@@ -77,11 +74,11 @@ contract PythPriceProviderTest is Helper {
     }
 
     function testConditionOneMetPyth() public {
-        uint256 conditionType = 1;
         uint256 marketIdOne = 1;
-        pythProvider.setConditionType(marketIdOne, conditionType);
+        uint256 strikePrice = 10000000000000001;
+
         (bool condition, int256 price) = pythProvider.conditionMet(
-            0.01 ether,
+            strikePrice,
             marketIdOne
         );
         assertTrue(price != 0);
@@ -89,8 +86,9 @@ contract PythPriceProviderTest is Helper {
     }
 
     function testConditionTwoMetPyth() public {
+        uint256 strikePrice = 2 ether;
         (bool condition, int256 price) = pythProvider.conditionMet(
-            2 ether,
+            strikePrice,
             marketId
         );
         assertTrue(price != 0);
@@ -110,19 +108,6 @@ contract PythPriceProviderTest is Helper {
 
         vm.expectRevert(PythPriceProvider.InvalidInput.selector);
         new PythPriceProvider(PYTH_CONTRACT, PYTH_FDUSD_FEED_ID, 0);
-    }
-
-    function testRevertConditionTypeSetPyth() public {
-        vm.expectRevert(PythPriceProvider.ConditionTypeSet.selector);
-        pythProvider.setConditionType(2, 0);
-    }
-
-    function testRevertInvalidInputConditionPyth() public {
-        vm.expectRevert(PythPriceProvider.InvalidInput.selector);
-        pythProvider.setConditionType(0, 0);
-
-        vm.expectRevert(PythPriceProvider.InvalidInput.selector);
-        pythProvider.setConditionType(0, 3);
     }
 
     function testRevertOraclePriceNegative() public {

--- a/test/V2/oracles/individual/RedstonePriceProvider.t.sol
+++ b/test/V2/oracles/individual/RedstonePriceProvider.t.sol
@@ -36,9 +36,6 @@ contract RedstonePriceProviderTest is Helper {
             "VST",
             TIME_OUT
         );
-
-        uint256 condition = 2;
-        redstoneProvider.setConditionType(marketId, condition);
     }
 
     ////////////////////////////////////////////////
@@ -80,9 +77,10 @@ contract RedstonePriceProviderTest is Helper {
         assertTrue(price != 0);
     }
 
-    function testConditionMet() public {
+    function testConditionMetPrice() public {
+        uint256 strike = 10001;
         (bool condition, int256 price) = redstoneProvider.conditionMet(
-            2 ether,
+            strike,
             marketId
         );
         assertTrue(price != 0);
@@ -90,11 +88,10 @@ contract RedstonePriceProviderTest is Helper {
     }
 
     function testConditionOneMetRedstone() public {
-        uint256 conditionType = 1;
+        uint256 strike = 10000000000000001; // 0.01 ether with 1 for first byte || 100011100001101111001001101111110000010000000000000001
         uint256 marketIdOne = 1;
-        redstoneProvider.setConditionType(marketIdOne, conditionType);
         (bool condition, int256 price) = redstoneProvider.conditionMet(
-            0.01 ether,
+            strike,
             marketIdOne
         );
         assertTrue(price != 0);
@@ -102,8 +99,9 @@ contract RedstonePriceProviderTest is Helper {
     }
 
     function testConditionTwoMetRedstone() public {
+        uint256 strike = 2 ether; // 2000000000000000000 || 1101111000001011011010110011101001110110010000000000000000000
         (bool condition, int256 price) = redstoneProvider.conditionMet(
-            2 ether,
+            strike,
             marketId
         );
         assertTrue(price != 0);
@@ -141,19 +139,6 @@ contract RedstonePriceProviderTest is Helper {
 
         vm.expectRevert(RedstonePriceProvider.InvalidInput.selector);
         new RedstonePriceProvider(address(factory), USDC_CHAINLINK, "USDC", 0);
-    }
-
-    function testRevertConditionTypeSetRedstone() public {
-        vm.expectRevert(RedstonePriceProvider.ConditionTypeSet.selector);
-        redstoneProvider.setConditionType(2, 0);
-    }
-
-    function testRevertInvalidInputConditionRedstone() public {
-        vm.expectRevert(RedstonePriceProvider.InvalidInput.selector);
-        redstoneProvider.setConditionType(0, 0);
-
-        vm.expectRevert(RedstonePriceProvider.InvalidInput.selector);
-        redstoneProvider.setConditionType(0, 3);
     }
 
     function testRevertOraclePriceZero() public {

--- a/test/V2/oracles/individual/RedstonePriceProvider.t.sol
+++ b/test/V2/oracles/individual/RedstonePriceProvider.t.sol
@@ -113,6 +113,67 @@ contract RedstonePriceProviderTest is Helper {
         assertEq(result, bytes32("VST"));
     }
 
+    function testConditionModuloRedstone() public {
+        uint256 marketIdOne = 1;
+
+        uint256 newStrike = 102938475758493948579595857473838937212; // Last bit is a 0
+        (bool condition, int256 price) = redstoneProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertTrue(price != 0);
+        assertEq(condition, true);
+
+        newStrike = 456768694934837282929101938900000; // Last bit is a 0
+        (condition, price) = redstoneProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 57890228; // Last bit is a 0
+        (condition, price) = redstoneProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+
+        newStrike = 98293028824; // Last bit is a 0
+        (condition, price) = redstoneProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+
+        newStrike = 76423729; // Last bit is a 1
+        (condition, price) = redstoneProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 238492107; // Last bit is a 1
+        (condition, price) = redstoneProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, true);
+
+        newStrike = 69838393845895948594939299227374844939833; // Last bit is a 1
+        (condition, price) = redstoneProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+
+        newStrike = 3334959458499438438922923847584939393839909; // Last bit is a 1
+        (condition, price) = redstoneProvider.conditionMet(
+            uint256(newStrike),
+            marketIdOne
+        );
+        assertEq(condition, false);
+    }
+
     ////////////////////////////////////////////////
     //              REVERT CASES                  //
     ////////////////////////////////////////////////


### PR DESCRIPTION
Updated individual oracle provider contacts to convert `strike` into `conditionType` when `conditionMet()` called:
- Removed `conditionType` setter
- Removed `conditionType` mapping
- Using modulo approach to fetch last bit of `_strike` in `conditionMet()`
- Tests updated